### PR TITLE
Update SKPayment+Promise.swift

### DIFF
--- a/Sources/SKPayment+Promise.swift
+++ b/Sources/SKPayment+Promise.swift
@@ -27,7 +27,7 @@ private class PaymentObserver: NSObject, SKPaymentTransactionObserver {
             return
         }
         switch transaction.transactionState {
-        case .purchased:
+        case .purchased, .restored:
             queue.finishTransaction(transaction)
             seal.fulfill(transaction)
             queue.remove(self)


### PR DESCRIPTION
According to [In-App Purchase Best Practices / Provide the paid content](https://developer.apple.com/library/content/technotes/tn2387/_index.html),

> Deliver the content or unlock your app's functionality when your app receives a transaction whose state is purchased or restored. These states indicate that a payment was received for the product being sold. As such, your customer expects to be provided with the paid content. 

Therefore .restored should be fulfill as .purchased.