### PR TITLE
'Cancel' for PromiseKit

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "CoreCancel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/PromiseKit" "087b3cf470890ff9ea841212e2f3e285fecf3988"

--- a/Sources/SKProductsRequest+Promise.swift
+++ b/Sources/SKProductsRequest+Promise.swift
@@ -18,6 +18,8 @@ extension SKProductsRequest {
      Sends the request to the Apple App Store.
 
      - Returns: A promise that fulfills if the request succeeds.
+     - Note: cancelling this promise will cancel the underlying task
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
     */
     public func start(_: PMKNamespacer) -> Promise<SKProductsResponse> {
         let proxy = SKDelegate(request: self)
@@ -65,16 +67,3 @@ fileprivate class SKDelegate: NSObject, SKProductsRequestDelegate, CancellableTa
 //        return true
 //    }
 //}
-
-//////////////////////////////////////////////////////////// Cancellable wrapper
-
-extension SKProductsRequest {
-    /**
-     Sends the request to the Apple App Store.
-     
-     - Returns: A cancellable promise that fulfills if the request succeeds.
-     */
-    public func cancellableStart(_: PMKNamespacer) -> CancellablePromise<SKProductsResponse> {
-        return cancellable(start(.promise))
-    }
-}

--- a/Sources/SKReceiptRefreshRequest+Promise.swift
+++ b/Sources/SKReceiptRefreshRequest+Promise.swift
@@ -9,7 +9,7 @@ extension SKReceiptRefreshRequest {
     }
 }
 
-private class ReceiptRefreshObserver: NSObject, SKRequestDelegate {
+private class ReceiptRefreshObserver: NSObject, SKRequestDelegate, CancellableTask {
     let (promise, seal) = Promise<SKReceiptRefreshRequest>.pending()
     let request: SKReceiptRefreshRequest
     var retainCycle: ReceiptRefreshObserver?
@@ -31,5 +31,22 @@ private class ReceiptRefreshObserver: NSObject, SKRequestDelegate {
     func request(_: SKRequest, didFailWithError error: Error) {
         seal.reject(error)
         retainCycle = nil
+    }
+
+    var isCancelled = false
+    
+    func cancel() {
+        request.cancel()
+        retainCycle = nil
+        isCancelled = true
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension SKReceiptRefreshRequest {
+    public func cancellablePromise() -> CancellablePromise<SKReceiptRefreshRequest> {
+        let rro = ReceiptRefreshObserver(request: self)
+        return CancellablePromise(task: rro, promise: rro.promise, resolver: rro.seal)
     }
 }

--- a/Tests/TestStoreKit.swift
+++ b/Tests/TestStoreKit.swift
@@ -20,3 +20,33 @@ class SKProductsRequestTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension SKProductsRequestTests {
+    func testCancel() {
+        class MockProductsRequest: SKProductsRequest {            
+            var isCancelled = false
+
+            override func start() {
+                after(seconds: 0.1).done {
+                    if !self.isCancelled {
+                        self.delegate?.productsRequest(self, didReceive: SKProductsResponse())
+                    }
+                }
+            }
+        }
+        
+        let ex = expectation(description: "")
+        
+        let request = MockProductsRequest()
+        request.cancellableStart(.promise).done { _ in
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }.cancel()
+        request.isCancelled = true
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/Tests/TestStoreKit.swift
+++ b/Tests/TestStoreKit.swift
@@ -40,7 +40,7 @@ extension SKProductsRequestTests {
         let ex = expectation(description: "")
         
         let request = MockProductsRequest()
-        request.cancellableStart(.promise).done { _ in
+        cancellable(request.start(.promise)).done { _ in
             XCTFail()
         }.catch(policy: .allErrors) {
             $0.isCancelled ? ex.fulfill() : XCTFail()


### PR DESCRIPTION
These are the diffs for option 1 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 1 the new cancellation code is included with CorePromise.

There repositories involved with the pull request for option 1 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
