### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
-github "mxcl/PromiseKit" ~> 6.0
+#github "mxcl/PromiseKit" ~> 6.0
+github "dougzilla32/PromiseKit" "PMKCancel"
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,3 @@
 github "mxcl/PromiseKit" ~> 6.0
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "dougzilla32/Cancel" "1.0.0"
-github "mxcl/PromiseKit" "6.3.4"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "mxcl/PromiseKit" "6.3.3"
+github "dougzilla32/Cancel" "1.0.0"
+github "mxcl/PromiseKit" "6.3.4"

--- a/PMKStoreKit.xcodeproj/project.pbxproj
+++ b/PMKStoreKit.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 			);
 			inputPaths = (
 				PromiseKit,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/Sources/SKReceiptRefreshRequest+Promise.swift
+++ b/Sources/SKReceiptRefreshRequest+Promise.swift
@@ -1,4 +1,5 @@
 #if !PMKCocoaPods
+import PMKCancel
 import PromiseKit
 #endif
 import StoreKit
@@ -9,7 +10,7 @@ extension SKReceiptRefreshRequest {
     }
 }
 
-private class ReceiptRefreshObserver: NSObject, SKRequestDelegate {
+private class ReceiptRefreshObserver: NSObject, SKRequestDelegate, CancellableTask {
     let (promise, seal) = Promise<SKReceiptRefreshRequest>.pending()
     let request: SKReceiptRefreshRequest
     var retainCycle: ReceiptRefreshObserver?
@@ -31,5 +32,22 @@ private class ReceiptRefreshObserver: NSObject, SKRequestDelegate {
     func request(_: SKRequest, didFailWithError error: Error) {
         seal.reject(error)
         retainCycle = nil
+    }
+
+    var isCancelled = false
+    
+    func cancel() {
+        request.cancel()
+        retainCycle = nil
+        isCancelled = true
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension SKReceiptRefreshRequest {
+    public func promiseCC() -> CancellablePromise<SKReceiptRefreshRequest> {
+        let rro = ReceiptRefreshObserver(request: self)
+        return CancellablePromise(task: rro, promise: rro.promise, resolver: rro.seal)
     }
 }


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
