### PR TITLE
Fix for an exception thrown when a transaction is in the purchasing state.

### DIFF
--- a/PMKStoreKit.xcodeproj/project.pbxproj
+++ b/PMKStoreKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		637B4A721D5D5FA400E1BC6C /* TestStoreKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637B4A701D5D5FA400E1BC6C /* TestStoreKit.swift */; };
 		637B4A741D5D5FC600E1BC6C /* PMKStoreKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 637B4A731D5D5FC600E1BC6C /* PMKStoreKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63C7FFF71D5C020D003BAE60 /* PMKStoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63C7FFA71D5BEE09003BAE60 /* PMKStoreKit.framework */; };
+		B95EDB3B216E07C300963D64 /* SKPaymentQueue+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95EDB3A216E07C300963D64 /* SKPaymentQueue+Promise.swift */; };
 		D3F6DBF31EA245750013E242 /* SKPayment+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F6DBF21EA245750013E242 /* SKPayment+Promise.swift */; };
 		D3F6DBF51EA246340013E242 /* SKReceiptRefreshRequest+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F6DBF41EA246340013E242 /* SKReceiptRefreshRequest+Promise.swift */; };
 /* End PBXBuildFile section */
@@ -40,6 +41,7 @@
 		63C7FFF21D5C020D003BAE60 /* PMKSKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKSKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		63CCF8121D5C0C4E00503216 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		63CCF8171D5C11B500503216 /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
+		B95EDB3A216E07C300963D64 /* SKPaymentQueue+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SKPaymentQueue+Promise.swift"; sourceTree = "<group>"; };
 		D3F6DBF21EA245750013E242 /* SKPayment+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "SKPayment+Promise.swift"; path = "Sources/SKPayment+Promise.swift"; sourceTree = SOURCE_ROOT; };
 		D3F6DBF41EA246340013E242 /* SKReceiptRefreshRequest+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "SKReceiptRefreshRequest+Promise.swift"; path = "Sources/SKReceiptRefreshRequest+Promise.swift"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -93,6 +95,7 @@
 				637B4A6B1D5D5F9B00E1BC6C /* SKProductsRequest+Promise.swift */,
 				D3F6DBF21EA245750013E242 /* SKPayment+Promise.swift */,
 				D3F6DBF41EA246340013E242 /* SKReceiptRefreshRequest+Promise.swift */,
+				B95EDB3A216E07C300963D64 /* SKPaymentQueue+Promise.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -221,6 +224,7 @@
 			files = (
 				D3F6DBF51EA246340013E242 /* SKReceiptRefreshRequest+Promise.swift in Sources */,
 				637B4A6D1D5D5F9B00E1BC6C /* SKRequest+AnyPromise.m in Sources */,
+				B95EDB3B216E07C300963D64 /* SKPaymentQueue+Promise.swift in Sources */,
 				637B4A6E1D5D5F9B00E1BC6C /* SKProductsRequest+Promise.swift in Sources */,
 				D3F6DBF31EA245750013E242 /* SKPayment+Promise.swift in Sources */,
 			);

--- a/Sources/SKPaymentQueue+Promise.swift
+++ b/Sources/SKPaymentQueue+Promise.swift
@@ -29,7 +29,7 @@ private class PaymentObserver: NSObject, SKPaymentTransactionObserver {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         self.transactions += transactions.filter { $0.transactionState == .restored }
-        transactions.forEach(queue.finishTransaction)
+        transactions.filter { $0.transactionState != .purchasing }.forEach(queue.finishTransaction)
     }
 
     func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {


### PR DESCRIPTION
Calling finishTransaction(_:) on a transaction that is in the SKPaymentTransactionState.purchasing state throws an exception.