### PR TITLE
Updated project file to use Swift 4.0 as default

### DIFF
--- a/PMKStoreKit.xcodeproj/project.pbxproj
+++ b/PMKStoreKit.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -369,7 +369,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.promisekit.StoreKit;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
Without this patch, Xcode 10.2 wasn't able to compile this library when using Carthage, becase Carthage doesn't allow developers to pass `SWIFT_VERSION` on a per-library basis. So let's move on to support Swift 4.x and newer only.