### PR TITLE
In iOS14 comparing payment fails for successful purchase.

### DIFF
--- a/Sources/SKPayment+Promise.swift
+++ b/Sources/SKPayment+Promise.swift
@@ -23,7 +23,7 @@ private class PaymentObserver: NSObject, SKPaymentTransactionObserver {
     }
     
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
-        guard let transaction = transactions.first(where: { $0.payment == payment }) else {
+        guard let transaction = transactions.first(where: { $0.payment.productIdentifier == payment.productIdentifier }) else {
             return
         }
         switch transaction.transactionState {


### PR DESCRIPTION
In case of success for purchasing product (case .purchased), transaction's payment is SKMutablePayment which is not equal to SKPayment when compared.